### PR TITLE
Fix regression remaining time datasets not containing anything

### DIFF
--- a/core/regression.py
+++ b/core/regression.py
@@ -6,10 +6,10 @@ import xgboost as xgb
 from sklearn import metrics
 from sklearn.cluster import KMeans
 from sklearn.ensemble import RandomForestRegressor
+from sklearn.externals import joblib
 from sklearn.linear_model import Lasso
 from sklearn.linear_model import LinearRegression
 from sklearn.metrics import mean_squared_error, mean_absolute_error
-from sklearn.externals import joblib
 
 from core.common import get_method_config
 from core.constants import KMEANS, LINEAR, RANDOM_FOREST, LASSO, NO_CLUSTER, XGBOOST
@@ -100,7 +100,6 @@ def no_clustering_train(original_test_data, train_data, test_data, regressor):
 
 
 def no_clustering_test(original_test_data, test_data, regressor):
-    print(test_data)
     original_test_data['prediction'] = regressor.predict(test_data)
     return original_test_data
 

--- a/core/tests/test_refactoring.py
+++ b/core/tests/test_refactoring.py
@@ -75,10 +75,10 @@ class RefactorProof(TestCase):
         job['label'] = LabelContainer()
         add_default_config(job)
         result, _ = calculate(job)
-        self.assertAlmostEqual(result['rmse'], 0.30439548)
-        self.assertAlmostEqual(result['mae'], 0.26033653)
-        self.assertAlmostEqual(result['rscore'], -0.00558834)
-        self.assertAlmostEqual(result['mape'], 62.6850596)
+        self.assertAlmostEqual(result['rmse'], 0.29435018)
+        self.assertAlmostEqual(result['mae'], 0.2264389)
+        self.assertAlmostEqual(result['rscore'], 0.059686980)
+        self.assertAlmostEqual(result['mape'], 50.73148628)
 
     def test_regression_no_cluster(self):
         self.maxDiff = None
@@ -88,7 +88,7 @@ class RefactorProof(TestCase):
         job['label'] = LabelContainer()
         add_default_config(job)
         result, _ = calculate(job)
-        self.assertAlmostEqual(result['rmse'], 0.29010989)
-        self.assertAlmostEqual(result['mae'], 0.22528624)
-        self.assertAlmostEqual(result['rscore'], 0.086583348)
-        self.assertAlmostEqual(result['mape'], 50.363624743)
+        self.assertAlmostEqual(result['rmse'], 0.29123518)
+        self.assertAlmostEqual(result['mae'], 0.22594042)
+        self.assertAlmostEqual(result['rscore'], 0.079483654)
+        self.assertAlmostEqual(result['mape'], 50.64461029)

--- a/core/tests/test_regression.py
+++ b/core/tests/test_regression.py
@@ -23,6 +23,7 @@ class TestRegression(TestCase):
 
     def test_reg_linear(self):
         job = self.get_job()
+        job["encoding"] = EncodingContainer(SIMPLE_INDEX, padding=ZERO_PADDING, prefix_length=13)
         job['clustering'] = 'noCluster'
         add_default_config(job)
         calculate(job)

--- a/encoders/common.py
+++ b/encoders/common.py
@@ -43,8 +43,9 @@ def encode_label_log(run_log: list, encoding: EncodingContainer, job_type: str, 
     # Regression only has remaining_time or number atr as label
     if job_type == REGRESSION:
         # Remove last events as worse for prediction
-        if label.type == REMAINING_TIME:
-            encoded_log = encoded_log.loc[encoded_log['label'] != 0.0]
+        # TODO filter out 0 labels. Doing it here means runtime errors for regression
+        # if label.type == REMAINING_TIME:
+        #     encoded_log = encoded_log.loc[encoded_log['label'] != 0.0]
         return encoded_log
     # Post processing
     if label.type == REMAINING_TIME or label.type == ATTRIBUTE_NUMBER or label.type == DURATION:


### PR DESCRIPTION
Previously there was a filter that removed rows with label of 0 as then the remaining time was 0, meaning the prediction would be trivial. This was estimated to improve the prediction quality.

Remove this filter so datasets contain rows.